### PR TITLE
Export fix for strange enhanced object literal syntax behavior please excuse the not-so-perfect title of this PR.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,4 +111,4 @@ function prepare(sql, ...params) {
   });
 }
 
-export default { open, close, run, get, all, each, exec, prepare };
+export default { open, close, run, get: get, all, each, exec, prepare };

--- a/src/index.js
+++ b/src/index.js
@@ -111,4 +111,6 @@ function prepare(sql, ...params) {
   });
 }
 
-export default { open, close, run, get: get, all, each, exec, prepare };
+/* eslint-disable object-shorthand */
+export default { get: get, open, close, run, all, each, exec, prepare };
+/* eslint-enable object-shorthand */


### PR DESCRIPTION
Hey, 

please excuse the not-so-perfect title of this PR.

In the current versions of node (I tested 5.4.x and 5.5.x) the new [es6 enhanced object literal syntax](https://github.com/lukehoban/es6features#enhanced-object-literals) does work if the object has the name 'get'. One should avoid the new syntax when dealing with an object named 'get'.

I didn't find any node in the specs about get being an reserved keyword, so maybe this is an node bug?

To reproduce this behavior:
```js
const foo = 1
const bar = 2
const get = 3

// works as expected:
const test1 = {foo, bar}
// works as expected too:
const test3 = {get: get, foo, bar}
// does not work
const test2 = {get, foo, bar}
/*
const test2 = {get, foo, bar}
                  ^

SyntaxError: Unexpected token ,
*/
```