### PR TITLE
Support using named parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
   },
   "eslintConfig": {
     "parser": "babel-eslint",
-    "extends": "airbnb/base"
+    "extends": "airbnb/base",
+    "rules": {
+      "prefer-rest-params": "off"
+    }
   },
   "dependencies": {
     "sqlite3": "^3.1.4"

--- a/src/Database.js
+++ b/src/Database.js
@@ -38,9 +38,12 @@ class Database {
     });
   }
 
-  run(sql, ...params) {
+  run(sql) {
+    const params = (arguments.length === 2 && typeof arguments[1] === 'object'
+                    ? arguments[1]
+                    : Array.prototype.slice.call(arguments, 1));
     return new this.Promise((resolve, reject) => {
-      this.driver.run(sql, params || [], function runExecResult(err) {
+      this.driver.run(sql, params, function runExecResult(err) {
         if (err) {
           reject(err);
         } else {
@@ -50,9 +53,12 @@ class Database {
     });
   }
 
-  get(sql, ...params) {
+  get(sql) {
+    const params = (arguments.length === 2 && typeof arguments[1] === 'object'
+                    ? arguments[1]
+                    : Array.prototype.slice.call(arguments, 1));
     return new this.Promise((resolve, reject) => {
-      this.driver.get(sql, params || [], (err, row) => {
+      this.driver.get(sql, params, (err, row) => {
         if (err) {
           reject(err);
         } else {
@@ -62,9 +68,12 @@ class Database {
     });
   }
 
-  all(sql, ...params) {
+  all(sql) {
+    const params = (arguments.length === 2 && typeof arguments[1] === 'object'
+                    ? arguments[1]
+                    : Array.prototype.slice.call(arguments, 1));
     return new this.Promise((resolve, reject) => {
-      this.driver.all(sql, params || [], (err, rows) => {
+      this.driver.all(sql, params, (err, rows) => {
         if (err) {
           reject(err);
         } else {
@@ -89,8 +98,11 @@ class Database {
     });
   }
 
-  each(sql, ...params) {
-    const callback = params.pop();
+  each(sql) {
+    const params = (arguments.length === 3 && typeof arguments[1] === 'object'
+                    ? arguments[1]
+                    : Array.prototype.slice.call(arguments, 1, arguments.length - 1));
+    const callback = arguments[arguments.length - 1];
     return new this.Promise((resolve) => {
       this.driver.each(sql, params, callback, (err, rowsCount = 0) => {
         if (err) {
@@ -102,9 +114,12 @@ class Database {
     });
   }
 
-  prepare(sql, ...params) {
+  prepare(sql) {
+    const params = (arguments.length === 2 && typeof arguments[1] === 'object'
+                    ? arguments[1]
+                    : Array.prototype.slice.call(arguments, 1));
     return new this.Promise((resolve, reject) => {
-      const stmt = this.driver.prepare(sql, ...params, (err) => {
+      const stmt = this.driver.prepare(sql, params, (err) => {
         if (err) {
           reject(err);
         } else {

--- a/src/Database.js
+++ b/src/Database.js
@@ -92,7 +92,13 @@ class Database {
   each(sql, ...params) {
     const callback = params.pop();
     return new this.Promise((resolve) => {
-      this.driver.each(sql, params, callback, resolve);
+      this.driver.each(sql, params, callback, (err, rowsCount = 0) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(rowsCount);
+        }
+      });
     });
   }
 

--- a/src/Database.js
+++ b/src/Database.js
@@ -42,12 +42,16 @@ class Database {
     const params = (arguments.length === 2 && typeof arguments[1] === 'object'
                     ? arguments[1]
                     : Array.prototype.slice.call(arguments, 1));
-    return new this.Promise((resolve, reject) => {
+    const Promise = this.Promise;
+    return new Promise((resolve, reject) => {
       this.driver.run(sql, params, function runExecResult(err) {
         if (err) {
           reject(err);
         } else {
-          resolve(this);
+          // Per https://github.com/mapbox/node-sqlite3/wiki/API#databaserunsql-param--callback
+          // when run() succeeds, the `this' object is a driver statement object. Wrap it as a
+          // Statement.
+          resolve(new Statement(this, Promise));
         }
       });
     });

--- a/src/Database.js
+++ b/src/Database.js
@@ -107,7 +107,7 @@ class Database {
                     ? arguments[1]
                     : Array.prototype.slice.call(arguments, 1, arguments.length - 1));
     const callback = arguments[arguments.length - 1];
-    return new this.Promise((resolve) => {
+    return new this.Promise((resolve, reject) => {
       this.driver.each(sql, params, callback, (err, rowsCount = 0) => {
         if (err) {
           reject(err);

--- a/src/Database.js
+++ b/src/Database.js
@@ -10,6 +10,7 @@
 import fs from 'fs';
 import path from 'path';
 import Statement from './Statement';
+import prepareParams from './utils';
 
 class Database {
 
@@ -39,9 +40,7 @@ class Database {
   }
 
   run(sql) {
-    const params = (arguments.length === 2 && typeof arguments[1] === 'object'
-                    ? arguments[1]
-                    : Array.prototype.slice.call(arguments, 1));
+    const params = prepareParams(arguments, { offset: 1 });
     const Promise = this.Promise;
     return new Promise((resolve, reject) => {
       this.driver.run(sql, params, function runExecResult(err) {
@@ -58,9 +57,7 @@ class Database {
   }
 
   get(sql) {
-    const params = (arguments.length === 2 && typeof arguments[1] === 'object'
-                    ? arguments[1]
-                    : Array.prototype.slice.call(arguments, 1));
+    const params = prepareParams(arguments, { offset: 1 });
     return new this.Promise((resolve, reject) => {
       this.driver.get(sql, params, (err, row) => {
         if (err) {
@@ -73,9 +70,7 @@ class Database {
   }
 
   all(sql) {
-    const params = (arguments.length === 2 && typeof arguments[1] === 'object'
-                    ? arguments[1]
-                    : Array.prototype.slice.call(arguments, 1));
+    const params = prepareParams(arguments, { offset: 1 });
     return new this.Promise((resolve, reject) => {
       this.driver.all(sql, params, (err, rows) => {
         if (err) {
@@ -103,9 +98,7 @@ class Database {
   }
 
   each(sql) {
-    const params = (arguments.length === 3 && typeof arguments[1] === 'object'
-                    ? arguments[1]
-                    : Array.prototype.slice.call(arguments, 1, arguments.length - 1));
+    const params = prepareParams(arguments, { offset: 1, excludeLastArg: true });
     const callback = arguments[arguments.length - 1];
     return new this.Promise((resolve, reject) => {
       this.driver.each(sql, params, callback, (err, rowsCount = 0) => {
@@ -119,9 +112,7 @@ class Database {
   }
 
   prepare(sql) {
-    const params = (arguments.length === 2 && typeof arguments[1] === 'object'
-                    ? arguments[1]
-                    : Array.prototype.slice.call(arguments, 1));
+    const params = prepareParams(arguments, { offset: 1 });
     return new this.Promise((resolve, reject) => {
       const stmt = this.driver.prepare(sql, params, (err) => {
         if (err) {

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -40,7 +40,7 @@ class Statement {
         if (err) {
           reject(err);
         } else {
-          resolve(this);
+          resolve();
         }
       });
     });

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -7,6 +7,8 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
+import prepareParams from './utils';
+
 class Statement {
 
   constructor(stmt, Promise) {
@@ -27,9 +29,7 @@ class Statement {
   }
 
   bind() {
-    const params = (arguments.length === 1 && typeof arguments[0] === 'object'
-                    ? arguments[0]
-                    : Array.prototype.slice.call(arguments));
+    const params = prepareParams(arguments);
     return new this.Promise((resolve, reject) => {
       this.stmt.bind(params, err => {
         if (err) {
@@ -62,9 +62,7 @@ class Statement {
   }
 
   run() {
-    const params = (arguments.length === 1 && typeof arguments[0] === 'object'
-                    ? arguments[0]
-                    : Array.prototype.slice.call(arguments));
+    const params = prepareParams(arguments);
     return new this.Promise((resolve, reject) => {
       this.stmt.run(params, err => {
         if (err) {
@@ -77,9 +75,7 @@ class Statement {
   }
 
   get() {
-    const params = (arguments.length === 1 && typeof arguments[0] === 'object'
-                    ? arguments[0]
-                    : Array.prototype.slice.call(arguments));
+    const params = prepareParams(arguments);
     return new this.Promise((resolve, reject) => {
       this.stmt.get(params, (err, row) => {
         if (err) {
@@ -92,9 +88,7 @@ class Statement {
   }
 
   all() {
-    const params = (arguments.length === 1 && typeof arguments[0] === 'object'
-                    ? arguments[0]
-                    : Array.prototype.slice.call(arguments));
+    const params = prepareParams(arguments);
     return new this.Promise((resolve, reject) => {
       this.stmt.all(params, (err, rows) => {
         if (err) {
@@ -107,9 +101,7 @@ class Statement {
   }
 
   each() {
-    const params = (arguments.length === 2 && typeof arguments[0] === 'object'
-                    ? arguments[0]
-                    : Array.prototype.slice.call(arguments, 0, arguments.length - 1));
+    const params = prepareParams(arguments, { excludeLastArg: true });
     const callback = arguments[arguments.length - 1];
     return new this.Promise((resolve, reject) => {
       this.stmt.each(params, callback, (err, rowsCount = 0) => {

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -72,11 +72,11 @@ class Statement {
 
   all(...params) {
     return new this.Promise((resolve, reject) => {
-      this.stmt.all(...params, err => {
+      this.stmt.all(...params, (err, rows) => {
         if (err) {
           reject(err);
         } else {
-          resolve(this);
+          resolve(rows);
         }
       });
     });

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -14,9 +14,12 @@ class Statement {
     this.Promise = Promise;
   }
 
-  bind(...params) {
+  bind() {
+    const params = (arguments.length === 1 && typeof arguments[0] === 'object'
+                    ? arguments[0]
+                    : Array.prototype.slice.call(arguments));
     return new this.Promise((resolve, reject) => {
-      this.stmt.bind(...params, err => {
+      this.stmt.bind(params, err => {
         if (err) {
           reject(err);
         } else {
@@ -46,9 +49,12 @@ class Statement {
     });
   }
 
-  run(...params) {
+  run() {
+    const params = (arguments.length === 1 && typeof arguments[0] === 'object'
+                    ? arguments[0]
+                    : Array.prototype.slice.call(arguments));
     return new this.Promise((resolve, reject) => {
-      this.stmt.run(...params, function runExecResult(err) {
+      this.stmt.run(params, function runExecResult(err) {
         if (err) {
           reject(err);
         } else {
@@ -58,9 +64,12 @@ class Statement {
     });
   }
 
-  get(...params) {
+  get() {
+    const params = (arguments.length === 1 && typeof arguments[0] === 'object'
+                    ? arguments[0]
+                    : Array.prototype.slice.call(arguments));
     return new this.Promise((resolve, reject) => {
-      this.stmt.get(...params, (err, row) => {
+      this.stmt.get(params, (err, row) => {
         if (err) {
           reject(err);
         } else {
@@ -70,9 +79,12 @@ class Statement {
     });
   }
 
-  all(...params) {
+  all() {
+    const params = (arguments.length === 1 && typeof arguments[0] === 'object'
+                    ? arguments[0]
+                    : Array.prototype.slice.call(arguments));
     return new this.Promise((resolve, reject) => {
-      this.stmt.all(...params, (err, rows) => {
+      this.stmt.all(params, (err, rows) => {
         if (err) {
           reject(err);
         } else {
@@ -82,10 +94,13 @@ class Statement {
     });
   }
 
-  each(...params) {
+  each() {
+    const params = (arguments.length === 2 && typeof arguments[0] === 'object'
+                    ? arguments[0]
+                    : Array.prototype.slice.call(arguments, 0, arguments.length - 1));
+    const callback = arguments[arguments.length - 1];
     return new this.Promise((resolve, reject) => {
-      const callback = params.pop();
-      this.stmt.each(...params, callback, (err, rowsCount = 0) => {
+      this.stmt.each(params, callback, (err, rowsCount = 0) => {
         if (err) {
           reject(err);
         } else {

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -14,6 +14,18 @@ class Statement {
     this.Promise = Promise;
   }
 
+  get sql() {
+    return this.stmt.sql;
+  }
+
+  get lastID() {
+    return this.stmt.lastID;
+  }
+
+  get changes() {
+    return this.stmt.changes;
+  }
+
   bind() {
     const params = (arguments.length === 1 && typeof arguments[0] === 'object'
                     ? arguments[0]
@@ -54,7 +66,7 @@ class Statement {
                     ? arguments[0]
                     : Array.prototype.slice.call(arguments));
     return new this.Promise((resolve, reject) => {
-      this.stmt.run(params, function runExecResult(err) {
+      this.stmt.run(params, err => {
         if (err) {
           reject(err);
         } else {

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -60,11 +60,11 @@ class Statement {
 
   get(...params) {
     return new this.Promise((resolve, reject) => {
-      this.stmt.get(...params, err => {
+      this.stmt.get(...params, (err, row) => {
         if (err) {
           reject(err);
         } else {
-          resolve(this);
+          resolve(row);
         }
       });
     });

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@
 
 function prepareParams(args, { offset = 0, excludeLastArg = false } = {}) {
   const hasOneParam = (args.length === (offset + 1 + (excludeLastArg ? 1 : 0)));
-  if (hasOneParam && typeof args[offset] === 'object') {
+  if (hasOneParam) {
     return args[offset];
   }
   return Array.prototype.slice.call(args, offset, args.length - (excludeLastArg ? 1 : 0));

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,16 @@
+/**
+ * SQLite client library for Node.js applications
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+function prepareParams(args, { offset = 0, excludeLastArg = false } = {}) {
+  const hasOneParam = (args.length === (offset + 1 + (excludeLastArg ? 1 : 0)));
+  if (hasOneParam && typeof args[offset] === 'object') {
+    return args[offset];
+  }
+  return Array.prototype.slice.call(args, offset, args.length - (excludeLastArg ? 1 : 0));
+}
+
+export default prepareParams;

--- a/test/spec.js
+++ b/test/spec.js
@@ -39,21 +39,26 @@ it('Should open a database connection', (done) => {
 it('Should allow named parameters to be used', (done) => {
   let p = db.open(':memory:');
   p = p.then(() => db.exec('CREATE TABLE tbl (col TEXT)'));
-  p = p.then(() => db.run('INSERT INTO tbl(col) VALUES (:col)', { ':col': 'something' }).then(stmt => {
-    expect(stmt.lastID).to.equal(1);
-  }));
-  p = p.then(() => db.get('SELECT col FROM tbl WHERE 1 = ? AND 5 = ?5', { 1: 1, 5: 5 }).then(result => {
-    expect(result).to.be.deep.equal({ col: 'something' });
-  }));
-  p = p.then(() => db.run('INSERT INTO tbl(col) VALUES ($col)', { $col: 'other thing' }).then(stmt => {
-    expect(stmt.lastID).to.equal(2);
-  }));
+  p = p.then(() => db.run('INSERT INTO tbl(col) VALUES (:col)', { ':col': 'something' })
+    .then(stmt => {
+      expect(stmt.lastID).to.equal(1);
+    }));
+  p = p.then(() => db.get('SELECT col FROM tbl WHERE 1 = ? AND 5 = ?5', { 1: 1, 5: 5 })
+    .then(result => {
+      expect(result).to.be.deep.equal({ col: 'something' });
+    }));
+  p = p.then(() => db.run('INSERT INTO tbl(col) VALUES ($col)', { $col: 'other thing' })
+    .then(stmt => {
+      expect(stmt.lastID).to.equal(2);
+    }));
   p = p.then(() => db.each('SELECT col FROM tbl WHERE ROWID = ?', [2], (err, result) => {
     expect(result).to.be.deep.equal({ col: 'other thing' });
   }).then(rowsCount => {
     expect(rowsCount).to.equal(1);
   }));
-  p = p.then(() => db.all('SELECT col FROM tbl WHERE 13 = @thirteen ORDER BY col DESC', { '@thirteen': 13 }).then(results => {
+  p = p.then(() => db.all('SELECT col FROM tbl WHERE 13 = @thirteen ORDER BY col DESC', {
+    '@thirteen': 13,
+  }).then(results => {
     expect(results).to.be.deep.equal([{ col: 'something' }, { col: 'other thing' }]);
   }));
   p = p.then(() => db.close());
@@ -63,28 +68,38 @@ it('Should allow named parameters to be used', (done) => {
 it('Should allow named parameters to be used with prepared statements', (done) => {
   let p = db.open(':memory:');
   p = p.then(() => db.exec('CREATE TABLE tbl (col TEXT)'));
-  p = p.then(() => db.prepare('INSERT INTO tbl(col) VALUES (:col)', { ':col': 'some text' }).then(stmt => stmt.run().then(stmt => {
-    expect(stmt.lastID).to.equal(1);
-    return stmt.finalize();
-  })));
-  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE 1 = ? AND 5 = ?5').then(stmt => stmt.bind({ 1: 1, 5: 5 })).then(stmt => stmt.get().then(result => {
-    expect(result).to.be.deep.equal({ col: 'some text' });
-    return stmt.finalize();
-  })));
-  p = p.then(() => db.prepare('INSERT INTO tbl(col) VALUES ($col)').then(stmt => stmt.run({ $col: 'other text' }).then(stmt => {
-    expect(stmt.lastID).to.equal(2);
-    return stmt.finalize();
-  })));
-  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE ROWID = ?').then(stmt => stmt.each([2], (err, result) => {
-    expect(result).to.be.deep.equal({ col: 'other text' });
-  }).then(rowsCount => {
-    expect(rowsCount).to.equal(1);
-    return stmt.finalize();
-  })));
-  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE 13 = @thirteen ORDER BY col DESC').then(stmt => stmt.all({ '@thirteen': 13 }).then(results => {
-    expect(results).to.be.deep.equal([{ col: 'some text' }, { col: 'other text' }]);
-    return stmt.finalize();
-  })));
+  p = p.then(() => db.prepare('INSERT INTO tbl(col) VALUES (:col)', { ':col': 'some text' })
+    .then(stmt => stmt.run())
+    .then(stmt => {
+      expect(stmt.lastID).to.equal(1);
+      return stmt.finalize();
+    }));
+  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE 1 = ? AND 5 = ?5')
+    .then(stmt => stmt.bind({ 1: 1, 5: 5 }))
+    .then(stmt => stmt.get()
+      .then(result => {
+        expect(result).to.be.deep.equal({ col: 'some text' });
+        return stmt.finalize();
+      })));
+  p = p.then(() => db.prepare('INSERT INTO tbl(col) VALUES ($col)')
+    .then(stmt => stmt.run({ $col: 'other text' }))
+    .then(stmt => {
+      expect(stmt.lastID).to.equal(2);
+      return stmt.finalize();
+    }));
+  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE ROWID = ?')
+    .then(stmt => stmt.each([2], (err, result) => {
+      expect(result).to.be.deep.equal({ col: 'other text' });
+    }).then(rowsCount => {
+      expect(rowsCount).to.equal(1);
+      return stmt.finalize();
+    })));
+  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE 13 = @thirteen ORDER BY col DESC')
+    .then(stmt => stmt.all({ '@thirteen': 13 })
+      .then(results => {
+        expect(results).to.be.deep.equal([{ col: 'some text' }, { col: 'other text' }]);
+        return stmt.finalize();
+      })));
   p = p.then(() => db.close());
   p.then(done, done);
 });
@@ -92,13 +107,15 @@ it('Should allow named parameters to be used with prepared statements', (done) =
 it('Should allow chaining Statement.run() calls', (done) => {
   let p = db.open(':memory:');
   p = p.then(() => db.exec('CREATE TABLE tbl (col1 TEXT, col2 TEXT, col3 TEXT)'));
-  p = p.then(() => db.prepare('INSERT INTO tbl(col1, col2, col3) VALUES (?, ?, ?)').then(stmt => stmt.run('a1', 'a2', 'a3')).then(stmt => {
-    expect(stmt.lastID).to.equal(1);
-    return stmt.run('b1', 'b2', 'b3');
-  }).then(stmt => {
-    expect(stmt.lastID).to.equal(2);
-    return stmt.finalize();
-  }));
+  p = p.then(() => db.prepare('INSERT INTO tbl(col1, col2, col3) VALUES (?, ?, ?)')
+    .then(stmt => stmt.run('a1', 'a2', 'a3')).then(stmt => {
+      expect(stmt.lastID).to.equal(1);
+      return stmt.run('b1', 'b2', 'b3');
+    })
+    .then(stmt => {
+      expect(stmt.lastID).to.equal(2);
+      return stmt.finalize();
+    }));
   p = p.then(() => db.all('SELECT col1, col2, col3 FROM tbl').then(results => {
     expect(results).to.be.deep.equal([{
       col1: 'a1',

--- a/test/spec.js
+++ b/test/spec.js
@@ -36,6 +36,57 @@ it('Should open a database connection', (done) => {
   p.then(done, done);
 });
 
+it('Should allow named parameters to be used', (done) => {
+  let p = db.open(':memory:');
+  p = p.then(() => db.exec('CREATE TABLE tbl (col TEXT)'));
+  p = p.then(() => db.run('INSERT INTO tbl(col) VALUES (:col)', { ':col': 'something' }).then(stmt => {
+    expect(stmt.lastID).to.equal(1);
+  }));
+  p = p.then(() => db.get('SELECT col FROM tbl WHERE 1 = ? AND 5 = ?5', { 1: 1, 5: 5 }).then(result => {
+    expect(result).to.be.deep.equal({ col: 'something' });
+  }));
+  p = p.then(() => db.run('INSERT INTO tbl(col) VALUES ($col)', { $col: 'other thing' }).then(stmt => {
+    expect(stmt.lastID).to.equal(2);
+  }));
+  p = p.then(() => db.each('SELECT col FROM tbl WHERE ROWID = ?', [2], (err, result) => {
+    expect(result).to.be.deep.equal({ col: 'other thing' });
+  }).then(rowsCount => {
+    expect(rowsCount).to.equal(1);
+  }));
+  p = p.then(() => db.all('SELECT col FROM tbl WHERE 13 = @thirteen ORDER BY col DESC', { '@thirteen': 13 }).then(results => {
+    expect(results).to.be.deep.equal([{ col: 'something' }, { col: 'other thing' }]);
+  }));
+  p = p.then(() => db.close());
+  p.then(done, done);
+});
+
+it('Should allow named parameters to be used with prepared statements', (done) => {
+  let p = db.open(':memory:');
+  p = p.then(() => db.exec('CREATE TABLE tbl (col TEXT)'));
+  p = p.then(() => db.prepare('INSERT INTO tbl(col) VALUES (:col)', { ':col': 'some text' }).then(stmt => stmt.run().then(stmt => {
+    expect(stmt.lastID).to.equal(1);
+  }).then(() => stmt.finalize())));
+  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE 1 = ? AND 5 = ?5').then(stmt => stmt.bind({ 1: 1, 5: 5 })).then(stmt => stmt.get().then(result => {
+    expect(result).to.be.deep.equal({ col: 'some text' });
+    return stmt.finalize();
+  })));
+  p = p.then(() => db.prepare('INSERT INTO tbl(col) VALUES ($col)').then(stmt => stmt.run({ $col: 'other text' }).then(stmt => {
+    expect(stmt.lastID).to.equal(2);
+  }).then(() => stmt.finalize())));
+  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE ROWID = ?').then(stmt => stmt.each([2], (err, result) => {
+    expect(result).to.be.deep.equal({ col: 'other text' });
+  }).then(rowsCount => {
+    expect(rowsCount).to.equal(1);
+    return stmt.finalize();
+  })));
+  p = p.then(() => db.prepare('SELECT col FROM tbl WHERE 13 = @thirteen ORDER BY col DESC').then(stmt => stmt.all({ '@thirteen': 13 }).then(results => {
+    expect(results).to.be.deep.equal([{ col: 'some text' }, { col: 'other text' }]);
+    return stmt.finalize();
+  })));
+  p = p.then(() => db.close());
+  p.then(done, done);
+});
+
 it('Should migrate the database', (done) => {
   let p = db.open(':memory:');
   p = p.then(() => db.migrate());

--- a/test/spec.js
+++ b/test/spec.js
@@ -131,6 +131,20 @@ it('Should allow chaining Statement.run() calls', (done) => {
   p.then(done, done);
 });
 
+it('Should handle BLOBs', (done) => {
+  const buf = Buffer.from('SGVsbG8gd29ybGQh', 'base64');
+  let p = db.open(':memory:');
+  p = p.then(() => db.exec('CREATE TABLE dat (b BLOB)'));
+  p = p.then(() => db.run('INSERT INTO dat(b) VALUES(?)', buf).then(stmt => {
+    expect(stmt.lastID).to.equal(1);
+  }));
+  p = p.then(() => db.get('SELECT b FROM dat').then(result => {
+    expect(result.b).to.be.instanceof(Buffer);
+    expect(result.b.toString('utf8')).to.equal('Hello world!');
+  }));
+  p.then(done, done);
+});
+
 it('Should migrate the database', (done) => {
   let p = db.open(':memory:');
   p = p.then(() => db.migrate());


### PR DESCRIPTION
In various places, rest parameter syntax (e.g. `...params`) was used to
represent the parameters to an SQL statement. The problem with this
approach is that it would not allow named parameters to be used, because
in order to use named parameters, an object must be passed as the params
to the driver method, but passing an object as the first parameter would
end up being wrapped in an array, and the driver method would treat the
object as a single parameter.

This commit replaces the uses of rest parameter syntax with a check
whether there is exactly one parameter whose type is 'object'. If so,
that object is used as the params to the driver method. Otherwise, an
appropriate slice of the `arguments` array-like object is used as the
params to the driver method.