### PR TITLE
bug: Fix sorting of schemas

### DIFF
--- a/src/Database.js
+++ b/src/Database.js
@@ -191,7 +191,7 @@ class Database {
     // Undo migrations that exist only in the database but not in files,
     // also undo the last migration if the `force` option was set to `last`.
     const lastMigration = migrations[migrations.length - 1];
-    for (const migration of dbMigrations.slice().sort((a, b) => a.id < b.id)) {
+    for (const migration of dbMigrations.slice().sort((a, b) => Math.sign(b.id - a.id))) {
       if (!migrations.some(x => x.id === migration.id) ||
         (force === 'last' && migration.id === lastMigration.id)) {
         await this.run('BEGIN');

--- a/src/Database.js
+++ b/src/Database.js
@@ -142,7 +142,7 @@ class Database {
             .map(x => x.match(/^(\d+).(.*?)\.sql$/))
             .filter(x => x !== null)
             .map(x => ({ id: Number(x[1]), name: x[2], filename: x[0] }))
-            .sort((a, b) => a.id > b.id));
+            .sort((a, b) => Math.sign(a.id - b.id)));
         }
       });
     });


### PR DESCRIPTION
Just had an app blow up in production because I exceeded 10 schemas on a db that's never been migrated before. 😨

Before: 
```
> [ { id: 7, name: 'rtg', filename: '007-rtg.sql' },
  { id: 1,
    name: 'initial-schema',
    filename: '001-initial-schema.sql' },
  { id: 8, name: 'betive', filename: '008-betive.sql' },
  { id: 3, name: 'enforce-keys', filename: '003-enforce-keys.sql' },
  { id: 2,
    name: 'first-provider',
    filename: '002-first-provider.sql' },
  { id: 4, name: 'dup-accounts', filename: '004-dup-accounts.sql' },
  { id: 5, name: 'program-url', filename: '005-program-url.sql' },
  { id: 6,
    name: 'gambling-stats',
    filename: '006-gambling-stats.sql' },
  { id: 9, name: 'radium', filename: '009-radium.sql' },
  { id: 10, name: 'programs', filename: '010-programs.sql' },
  { id: 11, name: 'rival', filename: '011-rival.sql' },
  { id: 12, name: 'rivals', filename: '012-rivals.sql' },
  { id: 13, name: 'egass', filename: '013-egass.sql' } ]
```

After:
```
> [ { id: 1,
    name: 'initial-schema',
    filename: '001-initial-schema.sql' },
  { id: 2,
    name: 'first-provider',
    filename: '002-first-provider.sql' },
  { id: 3, name: 'enforce-keys', filename: '003-enforce-keys.sql' },
  { id: 4, name: 'dup-accounts', filename: '004-dup-accounts.sql' },
  { id: 5, name: 'program-url', filename: '005-program-url.sql' },
  { id: 6,
    name: 'gambling-stats',
    filename: '006-gambling-stats.sql' },
  { id: 7, name: 'rtg', filename: '007-rtg.sql' },
  { id: 8, name: 'betive', filename: '008-betive.sql' },
  { id: 9, name: 'radium', filename: '009-radium.sql' },
  { id: 10, name: 'programs', filename: '010-programs.sql' },
  { id: 11, name: 'rival', filename: '011-rival.sql' },
  { id: 12, name: 'rivals', filename: '012-rivals.sql' },
  { id: 13, name: 'egass', filename: '013-egass.sql' } ]
```