### PR TITLE
Match only “down” as separator

### DIFF
--- a/src/Database.js
+++ b/src/Database.js
@@ -161,7 +161,7 @@ class Database {
         if (err) {
           reject(err);
         } else {
-          const [up, down] = data.split(/^--\s+?down/mi);
+          const [up, down] = data.split(/^--\s+?down\b/mi);
           if (!down) {
             const message = `The ${migration.filename} file does not contain '-- Down' separator.`;
             reject(new Error(message));


### PR DESCRIPTION
I happened to have a comment starting with `-- Downloaded` being considered as a separator… this commit ensures only the word “down” counts as a separator when it starts a comment.