### PR TITLE
Fixed issue resulting from typescript breaking change

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -60,5 +60,5 @@ declare module 'sqlite' {
   }
 
   export function open(filename: string, options?: { mode?: number, verbose?: boolean, promise?: typeof Promise }): Promise<Database>;
-  export default { open }
+  export default open;
 }


### PR DESCRIPTION
Breaking change to typescript caused construct to no longer be valid https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts