### PR TITLE
Remove executable code from ambient type file

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -60,5 +60,4 @@ declare module 'sqlite' {
   }
 
   export function open(filename: string, options?: { mode?: number, verbose?: boolean, promise?: typeof Promise }): Promise<Database>;
-  export default { open }
 }


### PR DESCRIPTION
As of TypeScript 2.6.1, ambient type files (`*.d.ts`) can no longer contain any executable code. Stated another way -- these files may only contain type information that disappears completely during the TS -> JS compilation process.

More info on this change here: https://github.com/Microsoft/TypeScript/issues/17991