### PR TITLE
expose sqlite3 configure method

### DIFF
--- a/src/Database.js
+++ b/src/Database.js
@@ -136,6 +136,13 @@ class Database {
   }
 
   /**
+   * Set a configuration option for the database.
+   */
+  configure(option, value) {
+    this.driver.configure(option, value);
+  }
+
+  /**
    * Migrates database schema to the latest version
    */
   async migrate({ force, table = 'migrations', migrationsPath = './migrations' } = {}) {

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -56,6 +56,9 @@ declare module 'sqlite' {
     prepare(sql: string): Promise<Statement>;
     prepare(sql: string, ...params: any[]): Promise<Statement>;
 
+    configure(option: "busyTimeout", value: number): void;
+    configure(option: string, value: any): void;
+
     migrate(options: { force?: string, table?: string, migrationsPath?: string }): Promise<Database>;
 
     on(event: "trace", listener: (sql: string) => void): void;


### PR DESCRIPTION
Without exposing the whole sqlite3 driver, this small change allows configure method.

more info: https://github.com/mapbox/node-sqlite3/wiki/API#databaseconfigureoption-value