### PR TITLE
Update sqlite3 to v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+### [v2.9.2]
+> 2018-04-20
+
+- Bump up baseline `sqlite3` version from `3.1.13` -> `4.0.0` ([#56](https://github.com/kriasoft/node-sqlite/pull/56))
+
 ### [v2.9.1]
 > 2018-01-13
 
@@ -92,6 +97,7 @@ All notable changes to this project will be documented in this file.
   (Harmony Modules)
 
 [unreleased]: https://github.com/kriasoft/node-sqlite/compare/v2.7.0...HEAD
+[v2.9.2]: https://github.com/kriasoft/node-sqlite/compare/v2.9.1...v2.9.2
 [v2.7.0]: https://github.com/kriasoft/node-sqlite/compare/v2.6.0...v2.7.0
 [v2.6.0]: https://github.com/kriasoft/node-sqlite/compare/v2.5.0...v2.6.0
 [v2.5.0]: https://github.com/kriasoft/node-sqlite/compare/v2.4.0...v2.5.0

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     }
   },
   "dependencies": {
-    "sqlite3": "3.1.13"
+    "sqlite3": "4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "sqlite",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "SQLite client for Node.js applications with SQL-based migrations API",
   "repository": "kriasoft/node-sqlite",
   "author": "Kriasoft <hello@kriasoft.com> (https://www.kriasoft.com)",


### PR DESCRIPTION
There's a prototype pollution vulnerability in `sqlite@3.1.13` introduced through an obsolete version of `node-pre-gyp` more info on which can be found here: https://snyk.io/test/npm/sqlite3/3.1.13

Updating to `sqlite@4.0.0` fixes this vulnerability: https://snyk.io/test/npm/sqlite3/4.0.0.

As far as I've checked, `v4.0.0` doesn't seem to introduce any breaking change that requires any changes to `node-sqlite`. So, this PR shouldn't break any thing.


*I've bumped the version & updated the changelog as well, please verify them as well.*