### PR TITLE
Merged declarations for methods that accepts...

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -36,19 +36,19 @@ declare module 'sqlite' {
     close(): Promise<void>;
 
     run(sql: string | SQLStatement): Promise<Statement>;
-    run(sql: string, ...params: any[]): Promise<Statement>;
+    run(sql: string | SQLStatement, ...params: any[]): Promise<Statement>;
 
     get(sql: string | SQLStatement): Promise<any>;
-    get(sql: string, ...params: any[]): Promise<any>;
+    get(sql: string | SQLStatement, ...params: any[]): Promise<any>;
 
     get<T>(sql: string | SQLStatement): Promise<T>;
-    get<T>(sql: string, ...params: any[]): Promise<T>;
+    get<T>(sql: string | SQLStatement, ...params: any[]): Promise<T>;
 
     all(sql: string | SQLStatement): Promise<any[]>;
-    all(sql: string, ...params: any[]): Promise<any[]>;
+    all(sql: string | SQLStatement, ...params: any[]): Promise<any[]>;
 
     all<T>(sql: string | SQLStatement): Promise<T[]>;
-    all<T>(sql: string, ...params: any[]): Promise<T[]>;
+    all<T>(sql: string | SQLStatement, ...params: any[]): Promise<T[]>;
 
     exec(sql: string): Promise<Database>;
 

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -35,35 +35,28 @@ declare module 'sqlite' {
   export interface Database {
     close(): Promise<void>;
 
-    run(sql: string): Promise<Statement>;
+    run(sql: string | SQLStatement): Promise<Statement>;
     run(sql: string, ...params: any[]): Promise<Statement>;
-    run(sql: SQLStatement): Promise<Statement>;
 
-    get(sql: string): Promise<any>;
+    get(sql: string | SQLStatement): Promise<any>;
     get(sql: string, ...params: any[]): Promise<any>;
-    get(sql: SQLStatement): Promise<any>;
 
-    get<T>(sql: string): Promise<T>;
+    get<T>(sql: string | SQLStatement): Promise<T>;
     get<T>(sql: string, ...params: any[]): Promise<T>;
-    get<T>(sql: SQLStatement): Promise<T>;
 
-    all(sql: string): Promise<any[]>;
+    all(sql: string | SQLStatement): Promise<any[]>;
     all(sql: string, ...params: any[]): Promise<any[]>;
-    all(sql: SQLStatement): Promise<any[]>;
 
-    all<T>(sql: string): Promise<T[]>;
+    all<T>(sql: string | SQLStatement): Promise<T[]>;
     all<T>(sql: string, ...params: any[]): Promise<T[]>;
-    all<T>(sql: SQLStatement): Promise<T[]>;
 
     exec(sql: string): Promise<Database>;
 
-    each(sql: string, callback?: (err: Error, row: any) => void): Promise<number>;
-    each(sql: string, ...params: any[]): Promise<number>;
-    each(sql: SQLStatement, callback?: (err: Error, row: any) => void): Promise<number>;
+    each(sql: string | SQLStatement, callback?: (err: Error, row: any) => void): Promise<number>;
+    each(sql: string | SQLStatement, ...params: any[]): Promise<number>;
 
-    prepare(sql: string): Promise<Statement>;
-    prepare(sql: string, ...params: any[]): Promise<Statement>;
-    prepare(sql: SQLStatement): Promise<Statement>;
+    prepare(sql: string | SQLStatement): Promise<Statement>;
+    prepare(sql: string | SQLStatement, ...params: any[]): Promise<Statement>;
 
     configure(option: "busyTimeout", value: number): void;
     configure(option: string, value: any): void;


### PR DESCRIPTION
... both string and SQLStatements in Database.

I was trying to create a unique function to be repeated using `Database.run` in Typescript. While defining the types supported by the function (`string | SQLStatement`), I run into the following error:

```
Argument of type 'string | SQLStatement' is not assignable to parameter of type 'SQLStatement'.
  Type 'string' is not assignable to type 'SQLStatement'.
```

I solved it by changing TS declaration file, by merging methods declaration in Database that supported `string` with the ones that support `SQLStatement`.

I hope this change will be appreciated.
Thank you.