### PR TITLE
Export class types for flow

### DIFF
--- a/src/main.js.flow
+++ b/src/main.js.flow
@@ -79,4 +79,6 @@ declare class Database {
   run(sql: string, ...params: DataType[]): Promise<Statement>;
 };
 
+export type { Database, Statement };
+
 declare export function open(filename: string, options?: OpenOptions): Promise<Database>;


### PR DESCRIPTION
Resolves the issue of `Database` and `Statement` objects being retrievable (via this library's api), but not possible to type annotate (on local code).