### PR TITLE
Use non-default imports rather than synthetic default imports

### DIFF
--- a/src/Statement.ts
+++ b/src/Statement.ts
@@ -1,4 +1,4 @@
-import sqlite from 'sqlite3'
+import * as sqlite from 'sqlite3'
 import { ISqlite } from './interfaces'
 
 /**

--- a/src/__tests__/Sqlite3.test.ts
+++ b/src/__tests__/Sqlite3.test.ts
@@ -2,7 +2,7 @@
 
 import { Database } from '../Database'
 import SQL from 'sql-template-strings'
-import sqlite3 from 'sqlite3'
+import * as sqlite3 from 'sqlite3'
 import { open } from '..'
 
 let db: Database

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 
-import sqlite3Offline from 'sqlite3-offline'
+import * as sqlite3Offline from 'sqlite3-offline'
 import { open } from '..'
-import sqlite3 from 'sqlite3'
+import * as sqlite3 from 'sqlite3'
 
 describe('index', () => {
   // enable the sqlite cached database or not

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 /// <reference types="./vendor-typings/sqlite3" />
 
-import sqlite3 from 'sqlite3'
+import * as sqlite3 from 'sqlite3'
 import { Statement } from './Statement'
 import { Database } from './Database'
 import { ISqlite, IMigrate } from './interfaces'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,7 +1,7 @@
 /// <reference types="./vendor-typings/sql-template-strings" />
 /// <reference types="./vendor-typings/sqlite3" />
 
-import sqlite3 from 'sqlite3'
+import * as sqlite3 from 'sqlite3'
 import { SQLStatement } from 'sql-template-strings'
 import { Statement } from './Statement'
 

--- a/src/utils/__tests__/migrate.test.ts
+++ b/src/utils/__tests__/migrate.test.ts
@@ -2,7 +2,7 @@
 
 import { migrate } from '../migrate'
 import { Database } from '../../Database'
-import sqlite3 from 'sqlite3'
+import * as sqlite3 from 'sqlite3'
 
 let db
 

--- a/src/utils/migrate.ts
+++ b/src/utils/migrate.ts
@@ -1,5 +1,5 @@
-import fs from 'fs'
-import path from 'path'
+import * as fs from 'fs'
+import * as path from 'path'
 import { Database } from '../Database'
 import { IMigrate } from '../interfaces'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
     "noImplicitAny": false,
     "strictNullChecks": false,
     "module": "commonjs",


### PR DESCRIPTION
Hello!  Thanks for the update on this last night.  I've had another look and think I've found the root of the particular problem I was having.  This project previously used allowSyntheticDefaultImports to allow modules without a default export defined to be used as though they have one.  Any consuming packages would then also need this TypeScript compiler configuration change; it's a workaround for some more exotic uses of module imports and isn't intended for general use (https://github.com/microsoft/TypeScript/issues/10895#issuecomment-246926958).

In this PR I've disabled allowSyntheticDefaultImports and adjusted module imports where there's been an impact.  Thanks!