### PR TITLE
Fix typescript defs for sqlite3 loadExtension()

### DIFF
--- a/src/vendor-typings/sqlite3/index.d.ts
+++ b/src/vendor-typings/sqlite3/index.d.ts
@@ -158,7 +158,7 @@ declare module 'sqlite3' {
     configure (option: 'busyTimeout', value: number): void
     interrupt (): void
 
-    loadExtension (path: string, callback?: (err: Error | null) => void)
+    loadExtension (path: string, callback?: (err: Error | null) => void): void
   }
 
   export function verbose (): sqlite3


### PR DESCRIPTION
This PR fixes the function definition.
Implicit "any" in definition file can cause compilation error in external project.