### PR TITLE
Fix invalid triple slash reference

### DIFF
--- a/src/vendor-typings/sqlite3/index.d.ts
+++ b/src/vendor-typings/sqlite3/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 declare module 'sqlite3' {
   // Type definitions for sqlite3 3.1
   // Project: http://github.com/mapbox/node-sqlite3
@@ -6,7 +8,6 @@ declare module 'sqlite3' {
   //                 Behind The Math <https://github.com/BehindTheMath>
   // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-  /// <reference types="node" />
   import events = require('events')
 
   export const OPEN_READONLY: number


### PR DESCRIPTION
Triple slash references need to be the [in first statements of a typescript source file to be recognized](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html), currently this one is ignored (at least in ts 3.8.3) and so the event type is not included in compilation (unless included elsewhere)

Also resolves https://github.com/haxiomic/dts2hx/issues/15