### PR TITLE
Revert filename optional; update filename checks instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ const db = await open({
    * Anonymous databases are not persisted and when closing the database
    * handle, their contents are lost.
    */
-  filename?: string
+  filename: string
 
   /**
    * One or more of sqlite3.OPEN_READONLY, sqlite3.OPEN_READWRITE and

--- a/docs/classes/_src_database_.database.md
+++ b/docs/classes/_src_database_.database.md
@@ -49,7 +49,7 @@ Promisified wrapper for the sqlite3#Database interface.
 
 \+ **new Database**(`config`: [Config](../interfaces/_src_interfaces_.isqlite.config.md)): *[Database](_src_database_.database.md)*
 
-*Defined in [src/Database.ts:18](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L18)*
+*Defined in [src/Database.ts:18](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L18)*
 
 **Parameters:**
 
@@ -65,7 +65,7 @@ Name | Type |
 
 • **config**: *[Config](../interfaces/_src_interfaces_.isqlite.config.md)*
 
-*Defined in [src/Database.ts:17](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L17)*
+*Defined in [src/Database.ts:17](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L17)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **db**: *Driver*
 
-*Defined in [src/Database.ts:18](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L18)*
+*Defined in [src/Database.ts:18](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L18)*
 
 ## Methods
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **all**‹**T**›(`sql`: [SqlType](../modules/_src_interfaces_.isqlite.md#sqltype), ...`params`: any[]): *Promise‹T›*
 
-*Defined in [src/Database.ts:255](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L255)*
+*Defined in [src/Database.ts:255](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L255)*
 
 Runs the SQL query with the specified parameters. The parameters are the same as the
 Database#run function, with the following differences:
@@ -116,7 +116,7 @@ ___
 
 ▸ **close**(): *Promise‹void›*
 
-*Defined in [src/Database.ts:79](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L79)*
+*Defined in [src/Database.ts:79](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L79)*
 
 Closes the database.
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **configure**(`option`: [ConfigureOption](../modules/_src_interfaces_.isqlite.md#configureoption), `value`: any): *any*
 
-*Defined in [src/Database.ts:94](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L94)*
+*Defined in [src/Database.ts:94](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L94)*
 
 **`see`** https://github.com/mapbox/node-sqlite3/wiki/API#databaseconfigureoption-value
 
@@ -147,7 +147,7 @@ ___
 
 ▸ **each**‹**T**›(`sql`: [SqlType](../modules/_src_interfaces_.isqlite.md#sqltype), ...`params`: any[]): *Promise‹number›*
 
-*Defined in [src/Database.ts:187](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L187)*
+*Defined in [src/Database.ts:187](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L187)*
 
 Runs the SQL query with the specified parameters and calls the callback once for each result
 row. The parameters are the same as the Database#run function, with the following differences:
@@ -188,7 +188,7 @@ ___
 
 ▸ **exec**(`sql`: [SqlType](../modules/_src_interfaces_.isqlite.md#sqltype)): *Promise‹void›*
 
-*Defined in [src/Database.ts:280](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L280)*
+*Defined in [src/Database.ts:280](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L280)*
 
 Runs all SQL queries in the supplied string. No result rows are retrieved. If a query fails,
 no subsequent statements will be executed (wrap it in a transaction if you want all
@@ -213,7 +213,7 @@ ___
 
 ▸ **get**‹**T**›(`sql`: [SqlType](../modules/_src_interfaces_.isqlite.md#sqltype), ...`params`: any[]): *Promise‹T | undefined›*
 
-*Defined in [src/Database.ts:150](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L150)*
+*Defined in [src/Database.ts:150](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L150)*
 
 Runs the SQL query with the specified parameters and resolves with
 with the first result row afterwards. If the result set is empty, returns undefined.
@@ -242,7 +242,7 @@ ___
 
 ▸ **getDatabaseInstance**(): *Driver*
 
-*Defined in [src/Database.ts:36](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L36)*
+*Defined in [src/Database.ts:36](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L36)*
 
 Returns the underlying sqlite3 Database instance
 
@@ -254,7 +254,7 @@ ___
 
 ▸ **loadExtension**(`path`: string): *Promise‹unknown›*
 
-*Defined in [src/Database.ts:325](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L325)*
+*Defined in [src/Database.ts:325](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L325)*
 
 Loads a compiled SQLite extension into the database connection object.
 
@@ -272,7 +272,7 @@ ___
 
 ▸ **migrate**(`config?`: [MigrationParams](../interfaces/_src_interfaces_.imigrate.migrationparams.md)): *Promise‹void›*
 
-*Defined in [src/Database.ts:340](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L340)*
+*Defined in [src/Database.ts:340](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L340)*
 
 Performs a database migration.
 
@@ -290,7 +290,7 @@ ___
 
 ▸ **on**(`event`: string, `listener`: any): *void*
 
-*Defined in [src/Database.ts:29](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L29)*
+*Defined in [src/Database.ts:29](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L29)*
 
 Event handler when verbose mode is enabled.
 
@@ -311,7 +311,7 @@ ___
 
 ▸ **open**(): *Promise‹void›*
 
-*Defined in [src/Database.ts:43](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L43)*
+*Defined in [src/Database.ts:43](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L43)*
 
 Opens the database
 
@@ -323,7 +323,7 @@ ___
 
 ▸ **parallelize**(): *void*
 
-*Defined in [src/Database.ts:360](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L360)*
+*Defined in [src/Database.ts:360](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L360)*
 
 **Returns:** *void*
 
@@ -333,7 +333,7 @@ ___
 
 ▸ **prepare**(`sql`: [SqlType](../modules/_src_interfaces_.isqlite.md#sqltype), ...`params`: any[]): *Promise‹[Statement](_src_statement_.statement.md)‹Stmt››*
 
-*Defined in [src/Database.ts:306](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L306)*
+*Defined in [src/Database.ts:306](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L306)*
 
 Prepares the SQL statement and optionally binds the specified parameters.
 When bind parameters are supplied, they are bound to the prepared statement.
@@ -355,7 +355,7 @@ ___
 
 ▸ **run**(`sql`: [SqlType](../modules/_src_interfaces_.isqlite.md#sqltype), ...`params`: any[]): *Promise‹[RunResult](../interfaces/_src_interfaces_.isqlite.runresult.md)‹Stmt››*
 
-*Defined in [src/Database.ts:112](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L112)*
+*Defined in [src/Database.ts:112](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L112)*
 
 Runs the SQL query with the specified parameters. It does not retrieve any result data.
 The function returns the Database object for which it was called to allow for function chaining.
@@ -377,7 +377,7 @@ ___
 
 ▸ **serialize**(): *void*
 
-*Defined in [src/Database.ts:351](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Database.ts#L351)*
+*Defined in [src/Database.ts:351](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Database.ts#L351)*
 
 The methods underneath requires creative work to implement. PRs / proposals accepted!
 

--- a/docs/classes/_src_statement_.statement.md
+++ b/docs/classes/_src_statement_.statement.md
@@ -39,7 +39,7 @@ Promisified wrapper for the sqlite3#Statement interface.
 
 \+ **new Statement**(`stmt`: S): *[Statement](_src_statement_.statement.md)*
 
-*Defined in [src/Statement.ts:8](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L8)*
+*Defined in [src/Statement.ts:8](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L8)*
 
 **Parameters:**
 
@@ -55,7 +55,7 @@ Name | Type |
 
 • **stmt**: *S*
 
-*Defined in [src/Statement.ts:8](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L8)*
+*Defined in [src/Statement.ts:8](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L8)*
 
 ## Methods
 
@@ -63,7 +63,7 @@ Name | Type |
 
 ▸ **all**‹**T**›(...`params`: any[]): *Promise‹T›*
 
-*Defined in [src/Statement.ts:146](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L146)*
+*Defined in [src/Statement.ts:146](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L146)*
 
 Binds parameters, executes the statement and calls the callback with all result rows.
 The parameters are the same as the Statement#run function, with the following differences:
@@ -92,7 +92,7 @@ ___
 
 ▸ **bind**(...`params`: any[]): *Promise‹void›*
 
-*Defined in [src/Statement.ts:27](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L27)*
+*Defined in [src/Statement.ts:27](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L27)*
 
 Binds parameters to the prepared statement.
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **each**‹**T**›(...`params`: any[]): *Promise‹number›*
 
-*Defined in [src/Statement.ts:180](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L180)*
+*Defined in [src/Statement.ts:180](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L180)*
 
 Binds parameters, executes the statement and calls the callback for each result row.
 
@@ -155,7 +155,7 @@ ___
 
 ▸ **finalize**(): *Promise‹void›*
 
-*Defined in [src/Statement.ts:58](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L58)*
+*Defined in [src/Statement.ts:58](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L58)*
 
 Finalizes the statement. This is typically optional, but if you experience long delays before
 the next query is executed, explicitly finalizing your statement might be necessary.
@@ -171,7 +171,7 @@ ___
 
 ▸ **get**‹**T**›(...`params`: any[]): *Promise‹T | undefined›*
 
-*Defined in [src/Statement.ts:118](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L118)*
+*Defined in [src/Statement.ts:118](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L118)*
 
 Binds parameters, executes the statement and retrieves the first result row.
 The parameters are the same as the Statement#run function, with the following differences:
@@ -199,7 +199,7 @@ ___
 
 ▸ **getStatementInstance**(): *S*
 
-*Defined in [src/Statement.ts:17](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L17)*
+*Defined in [src/Statement.ts:17](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L17)*
 
 Returns the underlying sqlite3 Statement instance
 
@@ -211,7 +211,7 @@ ___
 
 ▸ **reset**(): *Promise‹void›*
 
-*Defined in [src/Statement.ts:43](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L43)*
+*Defined in [src/Statement.ts:43](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L43)*
 
 Resets the row cursor of the statement and preserves the parameter bindings.
 Use this function to re-execute the same query with the same bindings.
@@ -224,7 +224,7 @@ ___
 
 ▸ **run**(...`params`: any[]): *Promise‹[RunResult](../interfaces/_src_interfaces_.isqlite.runresult.md)›*
 
-*Defined in [src/Statement.ts:85](https://github.com/kriasoft/node-sqlite/blob/244b720/src/Statement.ts#L85)*
+*Defined in [src/Statement.ts:85](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/Statement.ts#L85)*
 
 Binds parameters and executes the statement.
 

--- a/docs/interfaces/_src_interfaces_.imigrate.migrationfile.md
+++ b/docs/interfaces/_src_interfaces_.imigrate.migrationfile.md
@@ -22,7 +22,7 @@
 
 • **down**? : *string*
 
-*Defined in [src/interfaces.ts:103](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L103)*
+*Defined in [src/interfaces.ts:103](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L103)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **filename**: *string*
 
-*Defined in [src/interfaces.ts:101](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L101)*
+*Defined in [src/interfaces.ts:101](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L101)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/interfaces.ts:99](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L99)*
+*Defined in [src/interfaces.ts:99](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L99)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/interfaces.ts:100](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L100)*
+*Defined in [src/interfaces.ts:100](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L100)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **up**? : *string*
 
-*Defined in [src/interfaces.ts:102](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L102)*
+*Defined in [src/interfaces.ts:102](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L102)*

--- a/docs/interfaces/_src_interfaces_.imigrate.migrationparams.md
+++ b/docs/interfaces/_src_interfaces_.imigrate.migrationparams.md
@@ -20,7 +20,7 @@
 
 • **force**? : *boolean*
 
-*Defined in [src/interfaces.ts:87](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L87)*
+*Defined in [src/interfaces.ts:87](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L87)*
 
 If true, will force the migration API to rollback and re-apply the latest migration over
 again each time when Node.js app launches.
@@ -31,7 +31,7 @@ ___
 
 • **migrationsPath**? : *string*
 
-*Defined in [src/interfaces.ts:95](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L95)*
+*Defined in [src/interfaces.ts:95](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L95)*
 
 Path to the migrations folder. Default is `path.join(process.cwd(), 'migrations')`
 
@@ -41,6 +41,6 @@ ___
 
 • **table**? : *string*
 
-*Defined in [src/interfaces.ts:91](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L91)*
+*Defined in [src/interfaces.ts:91](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L91)*
 
 Migrations table name. Default is 'migrations'

--- a/docs/interfaces/_src_interfaces_.isqlite.config.md
+++ b/docs/interfaces/_src_interfaces_.isqlite.config.md
@@ -11,7 +11,7 @@
 ### Properties
 
 * [driver](_src_interfaces_.isqlite.config.md#driver)
-* [filename](_src_interfaces_.isqlite.config.md#optional-filename)
+* [filename](_src_interfaces_.isqlite.config.md#filename)
 * [mode](_src_interfaces_.isqlite.config.md#optional-mode)
 
 ## Properties
@@ -20,7 +20,7 @@
 
 • **driver**: *any*
 
-*Defined in [src/interfaces.ts:48](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L48)*
+*Defined in [src/interfaces.ts:48](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L48)*
 
 The database driver. Most will install `sqlite3` and use the `Database` class from it.
 As long as the library you are using conforms to the `sqlite3` API, you can use it as
@@ -36,11 +36,11 @@ const driver = sqlite.Database
 
 ___
 
-### `Optional` filename
+###  filename
 
-• **filename**? : *string*
+• **filename**: *string*
 
-*Defined in [src/interfaces.ts:27](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L27)*
+*Defined in [src/interfaces.ts:27](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L27)*
 
 Valid values are filenames, ":memory:" for an anonymous in-memory
 database and an empty string for an anonymous disk-based database.
@@ -53,7 +53,7 @@ ___
 
 • **mode**? : *number*
 
-*Defined in [src/interfaces.ts:33](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L33)*
+*Defined in [src/interfaces.ts:33](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L33)*
 
 One or more of sqlite3.OPEN_READONLY, sqlite3.OPEN_READWRITE and
 sqlite3.OPEN_CREATE. The default value is OPEN_READWRITE | OPEN_CREATE.

--- a/docs/interfaces/_src_interfaces_.isqlite.runresult.md
+++ b/docs/interfaces/_src_interfaces_.isqlite.runresult.md
@@ -24,7 +24,7 @@
 
 • **changes**? : *number*
 
-*Defined in [src/interfaces.ts:77](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L77)*
+*Defined in [src/interfaces.ts:77](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L77)*
 
 Number of rows changed.
 
@@ -37,7 +37,7 @@ ___
 
 • **lastID**? : *number*
 
-*Defined in [src/interfaces.ts:70](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L70)*
+*Defined in [src/interfaces.ts:70](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L70)*
 
 Row id of the inserted row.
 
@@ -50,7 +50,7 @@ ___
 
 • **stmt**: *[Statement](../classes/_src_statement_.statement.md)‹Stmt›*
 
-*Defined in [src/interfaces.ts:63](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L63)*
+*Defined in [src/interfaces.ts:63](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L63)*
 
 Statement object.
 

--- a/docs/interfaces/_src_interfaces_.isqlite.sqlobj.md
+++ b/docs/interfaces/_src_interfaces_.isqlite.sqlobj.md
@@ -19,7 +19,7 @@
 
 • **params**? : *any[]*
 
-*Defined in [src/interfaces.ts:11](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L11)*
+*Defined in [src/interfaces.ts:11](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L11)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **sql**: *string*
 
-*Defined in [src/interfaces.ts:10](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L10)*
+*Defined in [src/interfaces.ts:10](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L10)*

--- a/docs/modules/_src_index_.md
+++ b/docs/modules/_src_index_.md
@@ -14,7 +14,7 @@
 
 ▸ **open**‹**Driver**, **Stmt**›(`config`: [Config](../interfaces/_src_interfaces_.isqlite.config.md)): *Promise‹[Database](../classes/_src_database_.database.md)›*
 
-*Defined in [src/index.ts:11](https://github.com/kriasoft/node-sqlite/blob/244b720/src/index.ts#L11)*
+*Defined in [src/index.ts:11](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/index.ts#L11)*
 
 Opens a database for manipulation. Most users will call this to get started.
 

--- a/docs/modules/_src_interfaces_.isqlite.md
+++ b/docs/modules/_src_interfaces_.isqlite.md
@@ -21,7 +21,7 @@
 
 Ƭ **ConfigureOption**: *"trace" | "profile" | "busyTimeout"*
 
-*Defined in [src/interfaces.ts:51](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L51)*
+*Defined in [src/interfaces.ts:51](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L51)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 Ƭ **SqlType**: *SQLStatement | string*
 
-*Defined in [src/interfaces.ts:18](https://github.com/kriasoft/node-sqlite/blob/244b720/src/interfaces.ts#L18)*
+*Defined in [src/interfaces.ts:18](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/interfaces.ts#L18)*
 
 Allows for input of a normal SQL string or
 `sql-template-strings` object

--- a/docs/modules/_src_utils_migrate_.md
+++ b/docs/modules/_src_utils_migrate_.md
@@ -14,7 +14,7 @@
 
 ▸ **migrate**(`db`: [Database](../classes/_src_database_.database.md), `config`: [MigrationParams](../interfaces/_src_interfaces_.imigrate.migrationparams.md)): *Promise‹void›*
 
-*Defined in [src/utils/migrate.ts:12](https://github.com/kriasoft/node-sqlite/blob/244b720/src/utils/migrate.ts#L12)*
+*Defined in [src/utils/migrate.ts:12](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/utils/migrate.ts#L12)*
 
 Migrates database schema to the latest version
 

--- a/docs/modules/_src_utils_strings_.md
+++ b/docs/modules/_src_utils_strings_.md
@@ -14,7 +14,7 @@
 
 ▸ **toSqlParams**(`sql`: [SqlType](_src_interfaces_.isqlite.md#sqltype), `params`: any[]): *[SqlObj](../interfaces/_src_interfaces_.isqlite.sqlobj.md)*
 
-*Defined in [src/utils/strings.ts:10](https://github.com/kriasoft/node-sqlite/blob/244b720/src/utils/strings.ts#L10)*
+*Defined in [src/utils/strings.ts:10](https://github.com/kriasoft/node-sqlite/blob/d15b22e/src/utils/strings.ts#L10)*
 
 Allows for using strings and `sql-template-strings`. Converts both to a
 format that's usable by the SQL methods

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -45,8 +45,8 @@ export class Database<
       let { filename, mode, driver } = this.config
 
       // https://github.com/mapbox/node-sqlite3/wiki/API#new-sqlite3databasefilename-mode-callback
-      if (!filename) {
-        filename = ''
+      if (filename === null || filename === undefined) {
+        throw new Error('sqlite: filename cannot be null / undefined')
       }
 
       if (!driver) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,7 +24,7 @@ export namespace ISqlite {
      * Anonymous databases are not persisted and when closing the database
      * handle, their contents are lost.
      */
-    filename?: string
+    filename: string
 
     /**
      * One or more of sqlite3.OPEN_READONLY, sqlite3.OPEN_READWRITE and


### PR DESCRIPTION
The `filename` property is back to being required, but empty strings are valid values for the purpose of using an anonymous disk-based database.

Values of `undefined` or `null` for `filename` will throw.

Addresses https://github.com/kriasoft/node-sqlite/issues/123