### PR TITLE
Let migrations be read manually

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -93,13 +93,23 @@ export namespace IMigrate {
      * Path to the migrations folder. Default is `path.join(process.cwd(), 'migrations')`
      */
     migrationsPath?: string
+    /**
+     * Migration data read from migrations folder. `migrationsPath` will be ignored if this is
+     * provided.
+     */
+    migrations?: readonly MigrationData[]
   }
 
   export interface MigrationFile {
     id: number
     name: string
     filename: string
-    up?: string
-    down?: string
+  }
+
+  export interface MigrationData {
+    id: number
+    name: string
+    up: string
+    down: string
   }
 }

--- a/src/utils/__tests__/migrate.test.ts
+++ b/src/utils/__tests__/migrate.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { migrate } from '../migrate'
+import { migrate, readMigrations } from '../migrate'
 import { Database } from '../../Database'
 import * as sqlite3 from 'sqlite3'
 
@@ -43,6 +43,24 @@ describe('migration function', () => {
     result = await db.all('SELECT value from downless')
 
     expect(result[0].value).toBe('down migration is optional')
+
+    await db.close()
+  })
+
+  it('Should migrate the database without reading disk', async () => {
+    let migrations = await readMigrations()
+    migrations = migrations.slice(0, 2)
+
+    await migrate(db, { migrations })
+
+    let result = await db.all('SELECT id, name FROM migrations')
+    expect(result).toEqual([
+      { id: 1, name: 'initial' },
+      { id: 2, name: 'some-feature' }
+    ])
+
+    result = await db.all('SELECT * FROM Category')
+    expect(result).toEqual([{ id: 1, name: 'Test' }])
 
     await db.close()
   })

--- a/src/utils/migrate.ts
+++ b/src/utils/migrate.ts
@@ -5,51 +5,44 @@ import { IMigrate } from '../interfaces'
 
 import MigrationFile = IMigrate.MigrationFile
 import MigrationParams = IMigrate.MigrationParams
+import MigrationData = IMigrate.MigrationData
 
-/**
- * Migrates database schema to the latest version
- */
-export async function migrate (db: Database, config: MigrationParams = {}) {
-  config.force = config.force || false
-  config.table = config.table || 'migrations'
-  config.migrationsPath =
-    config.migrationsPath || path.join(process.cwd(), 'migrations')
-
-  const { force, table, migrationsPath } = config
-
-  /* eslint-disable no-await-in-loop */
+export async function readMigrations (migrationPath?: string) {
+  const migrationsPath = migrationPath || path.join(process.cwd(), 'migrations')
   const location = path.resolve(migrationsPath)
 
   // Get the list of migration files, for example:
   //   { id: 1, name: 'initial', filename: '001-initial.sql' }
   //   { id: 2, name: 'feature', filename: '002-feature.sql' }
-  const migrations = await new Promise<MigrationFile[]>((resolve, reject) => {
-    fs.readdir(location, (err, files) => {
-      if (err) {
-        return reject(err)
-      }
+  const migrationFiles = await new Promise<MigrationFile[]>(
+    (resolve, reject) => {
+      fs.readdir(location, (err, files) => {
+        if (err) {
+          return reject(err)
+        }
 
-      resolve(
-        files
-          .map(x => x.match(/^(\d+).(.*?)\.sql$/))
-          .filter(x => x !== null)
-          .map(x => ({ id: Number(x[1]), name: x[2], filename: x[0] }))
-          .sort((a, b) => Math.sign(a.id - b.id))
-      )
-    })
-  })
+        resolve(
+          files
+            .map(x => x.match(/^(\d+).(.*?)\.sql$/))
+            .filter(x => x !== null)
+            .map(x => ({ id: Number(x[1]), name: x[2], filename: x[0] }))
+            .sort((a, b) => Math.sign(a.id - b.id))
+        )
+      })
+    }
+  )
 
-  if (!migrations.length) {
+  if (!migrationFiles.length) {
     throw new Error(`No migration files found in '${location}'.`)
   }
 
   // Get the list of migrations, for example:
   //   { id: 1, name: 'initial', filename: '001-initial.sql', up: ..., down: ... }
   //   { id: 2, name: 'feature', filename: '002-feature.sql', up: ..., down: ... }
-  await Promise.all(
-    migrations.map(
+  return Promise.all(
+    migrationFiles.map(
       migration =>
-        new Promise((resolve, reject) => {
+        new Promise<MigrationData>((resolve, reject) => {
           const filename = path.join(location, migration.filename)
           fs.readFile(filename, 'utf-8', (err, data) => {
             if (err) {
@@ -58,15 +51,27 @@ export async function migrate (db: Database, config: MigrationParams = {}) {
 
             const [up, down] = data.split(/^--\s+?down\b/im)
 
-            /* eslint-disable no-param-reassign */
-            migration.up = up.replace(/^-- .*?$/gm, '').trim() // Remove comments
-            migration.down = down ? down.trim() : '' // and trim whitespaces
-            /* eslint-enable no-param-reassign */
-            resolve()
+            const migrationData = migration as Partial<MigrationData>
+            migrationData.up = up.replace(/^-- .*?$/gm, '').trim() // Remove comments
+            migrationData.down = down ? down.trim() : '' // and trim whitespaces
+            resolve(migrationData as MigrationData)
           })
         })
     )
   )
+}
+
+/**
+ * Migrates database schema to the latest version
+ */
+export async function migrate (db: Database, config: MigrationParams = {}) {
+  config.force = config.force || false
+  config.table = config.table || 'migrations'
+
+  const { force, table } = config
+  const migrations = config.migrations
+    ? config.migrations
+    : await readMigrations(config.migrationsPath)
 
   // Create a database table for migrations meta data if it doesn't exist
   await db.run(`CREATE TABLE IF NOT EXISTS "${table}" (


### PR DESCRIPTION
I like the migrations feature, but I'm working on a bundled JavaScript project where I want to have control over how the migrations data is read off the disk. It would be great if the data could be supplied directly to the migrate function from memory, without involving the filesystem.