### PR TITLE
Have native sqlite errors contain stack traces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite",
-  "version": "4.0.25",
+  "version": "4.1.0",
   "description": "SQLite client for Node.js applications with SQL-based migrations API written in Typescript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -6,6 +6,7 @@ import { migrate } from './utils/migrate'
 import { toSqlParams } from './utils/strings'
 
 import MigrationParams = IMigrate.MigrationParams
+import { formatError } from './utils/format-error'
 
 /**
  * Promisified wrapper for the sqlite3#Database interface.
@@ -56,7 +57,7 @@ export class Database<
       if (mode) {
         this.db = new driver(filename, mode, err => {
           if (err) {
-            return reject(err)
+            return reject(formatError(err))
           }
 
           resolve()
@@ -64,7 +65,7 @@ export class Database<
       } else {
         this.db = new driver(filename, err => {
           if (err) {
-            return reject(err)
+            return reject(formatError(err))
           }
 
           resolve()
@@ -80,7 +81,7 @@ export class Database<
     return new Promise((resolve, reject) => {
       this.db.close(err => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve()
@@ -118,7 +119,7 @@ export class Database<
 
       this.db.run(sqlObj.sql, ...sqlObj.params, function (err) {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve({
@@ -156,7 +157,7 @@ export class Database<
 
       this.db.get(sqlObj.sql, ...sqlObj.params, (err, row?: T) => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve(row)
@@ -236,14 +237,14 @@ export class Database<
         ...sqlObj.params,
         (err, row) => {
           if (err) {
-            return callback(err, null)
+            return callback(formatError(err), null)
           }
 
           callback(null, row)
         },
         (err, count) => {
           if (err) {
-            return reject(err)
+            return reject(formatError(err))
           }
 
           resolve(count)
@@ -281,7 +282,7 @@ export class Database<
 
       this.db.all(sqlObj.sql, ...sqlObj.params, (err, rows?: T) => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve(rows)
@@ -307,7 +308,7 @@ export class Database<
 
       this.db.exec(sqlObj.sql, err => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve()
@@ -350,7 +351,7 @@ export class Database<
     return new Promise((resolve, reject) => {
       this.db.loadExtension(path, err => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve()

--- a/src/Statement.ts
+++ b/src/Statement.ts
@@ -1,5 +1,6 @@
 import * as sqlite from 'sqlite3'
 import { ISqlite } from './interfaces'
+import { formatError } from './utils/format-error'
 
 /**
  * Promisified wrapper for the sqlite3#Statement interface.
@@ -28,7 +29,7 @@ export class Statement<S extends sqlite.Statement = sqlite.Statement> {
     return new Promise((resolve, reject) => {
       this.stmt.bind(...params, err => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve()
@@ -59,7 +60,7 @@ export class Statement<S extends sqlite.Statement = sqlite.Statement> {
     return new Promise((resolve, reject) => {
       this.stmt.finalize(err => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve()
@@ -88,7 +89,7 @@ export class Statement<S extends sqlite.Statement = sqlite.Statement> {
 
       this.stmt.run(...params, function (err) {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve({
@@ -119,7 +120,7 @@ export class Statement<S extends sqlite.Statement = sqlite.Statement> {
     return new Promise((resolve, reject) => {
       this.stmt.get(...params, (err, row?: T) => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve(row)
@@ -147,7 +148,7 @@ export class Statement<S extends sqlite.Statement = sqlite.Statement> {
     return new Promise((resolve, reject) => {
       this.stmt.all(...params, (err, rows?: T) => {
         if (err) {
-          return reject(err)
+          return reject(formatError(err))
         }
 
         resolve(rows)
@@ -220,14 +221,14 @@ export class Statement<S extends sqlite.Statement = sqlite.Statement> {
         ...params,
         (err, row) => {
           if (err) {
-            return callback(err, null)
+            return callback(formatError(err), null)
           }
 
           callback(null, row)
         },
         (err, count) => {
           if (err) {
-            return reject(err)
+            return reject(formatError(err))
           }
 
           resolve(count)

--- a/src/__tests__/Sqlite3.test.ts
+++ b/src/__tests__/Sqlite3.test.ts
@@ -84,6 +84,23 @@ describe('Sqlite3Database', () => {
     }
   })
 
+  it('should have stack traces on errors', async () => {
+    db = new Database({
+      filename: ':memory:',
+      driver: sqlite3.Database
+    })
+
+    await db.open()
+
+    try {
+      await db.all('abcd')
+    } catch (e) {
+      expect(e.stack).toBeDefined()
+      // In the native errors, the stack was filled with the message value
+      expect(e.stack).not.toEqual(e.message)
+    }
+  })
+
   it('should allow named parameters to be used', async () => {
     db = new Database({
       filename: ':memory:',

--- a/src/utils/__tests__/format-error.test.ts
+++ b/src/utils/__tests__/format-error.test.ts
@@ -1,0 +1,26 @@
+import { formatError } from '../format-error'
+
+describe('format-error', () => {
+  it('should return Error instance without modification', () => {
+    const err = new Error('test')
+    expect(formatError(err)).toEqual(err)
+  })
+
+  it('should convert objects to an Error instance', () => {
+    const err = { custom: 'prop' }
+    const newErr = formatError(err)
+    expect(newErr['custom']).toEqual('prop')
+  })
+
+  it('should handle pure string errors', () => {
+    const err = 'test'
+    const newErr = formatError(err)
+    expect(newErr.message).toEqual('test')
+  })
+
+  it('should return errors of an unknown type', () => {
+    const err = 1234
+    const newErr = formatError(err)
+    expect(newErr.message).toEqual('1234')
+  })
+})

--- a/src/utils/format-error.ts
+++ b/src/utils/format-error.ts
@@ -1,0 +1,26 @@
+export function formatError (err: any) {
+  if (err instanceof Error) {
+    return err
+  }
+
+  if (typeof err === 'object') {
+    const newError = new Error()
+
+    for (let prop in err) {
+      newError[prop] = err[prop]
+    }
+
+    // message isn't part of the enumerable set
+    if (err.message) {
+      newError.message = err.message
+    }
+
+    return newError
+  }
+
+  if (typeof err === 'string') {
+    return new Error(err)
+  }
+
+  return new Error(err)
+}


### PR DESCRIPTION
Addresses https://github.com/kriasoft/node-sqlite/issues/156

This ensures that errors thrown from the sqlite driver now
have stack traces and are of an `Error` type.

Thanks to @fresheneesz for initial troubleshooting and initial
code to help fix the issue.

This is a minor level version update as to not break implementations
that may handle errors in their own way prior to this fix.