### PR TITLE
Support TS 4.7+ node16/next module mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "type": "commonjs",
   "exports": {
     "require": "./build/index.js",
-    "import": "./build/index.mjs"
+    "import": "./build/index.mjs",
+    "types": "./build/index.d.ts"
   },
   "scripts": {
     "build": "npm run build:clean && npm run compile && cp -R src/index.mjs src/vendor-typings build",


### PR DESCRIPTION
in TS 4.7+ node16/next module mode, if library contains`exports` section, TypeScript compiler will only reads `exports.**.types` field.

more info: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/