### PR TITLE
move `types` condition to the front

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "types": "build/index.d.ts",
   "type": "commonjs",
   "exports": {
+    "types": "./build/index.d.ts",
     "require": "./build/index.js",
-    "import": "./build/index.mjs",
-    "types": "./build/index.d.ts"
+    "import": "./build/index.mjs"
   },
   "scripts": {
     "build": "npm run build:clean && npm run compile && cp -R src/index.mjs src/vendor-typings build",


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "🎭 Masquerading as CJS" remains here. You can check the reported errors [here](https://arethetypeswrong.github.io/?p=sqlite%404.1.2)