### PR TITLE
Remove `params` parameter from `exec` function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite",
-      "version": "4.2.0",
+      "version": "5.0.0",
       "license": "MIT",
       "devDependencies": {
         "@theo.gravity/changelog-version": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "description": "SQLite client for Node.js applications with SQL-based migrations API written in Typescript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -299,12 +299,11 @@ export class Database<
    * Comments are not allowed and will lead to runtime errors.
    *
    * @param {string} sql The SQL query to run.
-   * @param {any} [params, ...] Same as the `params` parameter of `all`
    * @see https://github.com/mapbox/node-sqlite3/wiki/API#databaseexecsql-callback
    */
-  exec (sql: ISqlite.SqlType, ...params: any[]): Promise<void> {
+  exec (sql: ISqlite.SqlType): Promise<void> {
     return new Promise((resolve, reject) => {
-      const sqlObj = toSqlParams(sql, params)
+      const sqlObj = toSqlParams(sql)
 
       this.db.exec(sqlObj.sql, err => {
         if (err) {


### PR DESCRIPTION
As `exec` is not a part of `Statement` (https://github.com/TryGhost/node-sqlite3/blob/master/src/statement.cc#L17), but a part of `Database` itself (https://github.com/TryGhost/node-sqlite3/blob/master/src/database.cc#L21), it does not support `params` binding. So, we should not expose `params` to the `exec` public interface here. Also, this corresponds to `node-sqlite3` API docs (https://github.com/TryGhost/node-sqlite3/wiki/API#execsql--callback).